### PR TITLE
MAT-1359 - add split step indices to public repo

### DIFF
--- a/beep/structure.py
+++ b/beep/structure.py
@@ -662,6 +662,7 @@ class RawCyclerRun(MSONable):
         """
         run_parameter, all_parameters = get_protocol_parameters(self.filename)
         # Logic for interpolation variables and diagnostic cycles
+        diagnostic_available = False
         if run_parameter is not None:
             if {'capacity_nominal'}.issubset(run_parameter.columns.tolist()):
                 nominal_capacity = run_parameter['capacity_nominal'].iloc[0]
@@ -681,12 +682,10 @@ class RawCyclerRun(MSONable):
                                             "cycle_type": hppc_rpt,
                                             "length": hppc_rpt_len,
                                             "diagnostic_starts_at": diagnostic_starts_at}
-        else:
-            diagnostic_available = False
 
         return v_range, resolution, nominal_capacity, full_fast_charge, diagnostic_available
 
-    def to_processed_cycler_run(self, v_range=None, resolution=1000):
+    def to_processed_cycler_run(self):
         """
         Method for converting to ProcessedCyclerRun
 

--- a/beep/structure.py
+++ b/beep/structure.py
@@ -297,33 +297,6 @@ class RawCyclerRun(MSONable):
         else:
             return summary.iloc[:-1]
 
-    def get_diagnostic_summary(self, summary, stat_name=None, stat_variable=None,
-                               nominal_capacity=None,
-                               c_rate_bounds=None,
-                               min_n_steps_diagnostic=None
-                               ):
-        """
-        Gets summary statistics for data according to args
-
-        Args:
-            summary (dataframe): dataframe containing columns of summary statistics by cycle (row).
-            stat_name (string): Column name for the statistic to be added.
-            stat_variable (string): Column name to use for the computation of the summary statistic.
-            nominal_capacity (float): nominal capacity for summary stats.
-            c_rate_bounds (list): list of upper and lower bound for the c-rate to recognize the diagnostic.
-            min_n_steps_diagnostic (int): number of steps in diagnostic cycle must exceed this threshold.
-
-        Returns:
-            pandas.DataFrame: summary statistics by cycle.
-
-        """
-        summary[stat_name] = self.data.groupby('cycle_index'). \
-            apply(lambda g: self.is_diagnostic_cycle(g, stat_variable,
-                                                     nominal_capacity,
-                                                     c_rate_bounds,
-                                                     min_n_steps_diagnostic))
-        return summary
-
     def diagnostic_summary(self, diagnostic_available):
         """
         Gets summary statistics for data according to location of diagnostic cycles in the data


### PR DESCRIPTION
Adds split diagnostic cycling (authored by @chirranjeevigopal-TRI).

I've also done a few cleanup-oriented things in this PR, namely:
* Minor formatting on beep.structure.py
* Moved the default diagnostic_available setting outside of the conditional so as to cover all cases (previously diagnostic_available could be unset with a unspecified diagnostic criteria in the parameter file).
* Removed the `v_range` and `resolution` parameters from RawCyclerRun.to_processed_cycler_run, since they weren't being used.