### PR TITLE
Standalone tests

### DIFF
--- a/beep/__init__.py
+++ b/beep/__init__.py
@@ -44,6 +44,10 @@ VALIDATION_SCHEMA_DIR = os.path.join(MODULE_DIR, "validation_schemas")
 PROCEDURE_TEMPLATE_DIR = os.path.join(MODULE_DIR, "procedure_templates")
 MODEL_DIR = os.path.join(MODULE_DIR, "models")
 
+LOG_DIR = os.path.join(MODULE_DIR, "logs")
+if not os.path.isdir(LOG_DIR):
+    os.mkdir(LOG_DIR)
+
 # Get S3 cache location from env or use default in repo
 S3_CACHE = os.environ.get("BEEP_S3_CACHE",
                           os.path.join(MODULE_DIR, "..", "s3_cache"))

--- a/beep/__init__.py
+++ b/beep/__init__.py
@@ -39,8 +39,6 @@ if ENVIRONMENT is None or ENVIRONMENT not in config.keys():
                      + f'Found: {ENVIRONMENT}')
 
 MODULE_DIR = os.path.dirname(__file__)
-TEST_DIR = os.path.join(MODULE_DIR, "tests")
-TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
 CONVERSION_SCHEMA_DIR = os.path.join(MODULE_DIR, "conversion_schemas")
 VALIDATION_SCHEMA_DIR = os.path.join(MODULE_DIR, "validation_schemas")
 PROCEDURE_TEMPLATE_DIR = os.path.join(MODULE_DIR, "procedure_templates")

--- a/beep/__init__.py
+++ b/beep/__init__.py
@@ -78,7 +78,7 @@ if 'stdout' in config[ENVIRONMENT]['logging']['streams']:
     hdlr.setFormatter(formatter)
     logger.addHandler(hdlr)
 if 'file' in config[ENVIRONMENT]['logging']['streams']:
-    log_file = os.path.join(TEST_FILE_DIR, "Testing_logger.log")
+    log_file = os.path.join(MODULE_DIR, "Testing_logger.log")
     hdlr = logging.FileHandler(log_file, 'a')
     hdlr.setFormatter(formatter)
     logger.addHandler(hdlr)

--- a/beep/tests/test_collate.py
+++ b/beep/tests/test_collate.py
@@ -7,7 +7,9 @@ from monty.serialization import loadfn
 from monty.tempfile import ScratchDir
 from pathlib import Path
 from beep.collate import get_parameters_fastcharge, get_parameters_oed, process_files_json
-from beep import TEST_FILE_DIR
+
+TEST_DIR = os.path.dirname(__file__)
+TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
 
 
 class CollateTest(unittest.TestCase):

--- a/beep/tests/test_end_to_end.py
+++ b/beep/tests/test_end_to_end.py
@@ -14,7 +14,10 @@ from monty.serialization import loadfn
 from botocore.exceptions import NoRegionError, NoCredentialsError
 
 from beep import collate, validate, structure, featurize,\
-    run_model, TEST_FILE_DIR, MODEL_DIR
+    run_model, MODEL_DIR
+
+TEST_DIR = os.path.dirname(__file__)
+TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
 
 
 class EndToEndTest(unittest.TestCase):

--- a/beep/tests/test_events.py
+++ b/beep/tests/test_events.py
@@ -10,7 +10,10 @@ import boto3
 from dateutil.tz import tzutc
 from botocore.exceptions import NoRegionError, NoCredentialsError
 from beep.utils import KinesisEvents, Logger
-from beep import TEST_FILE_DIR, ENVIRONMENT, __version__
+from beep import ENVIRONMENT, __version__
+
+TEST_DIR = os.path.dirname(__file__)
+TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
 
 
 class KinesisEventsTest(unittest.TestCase):

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -60,6 +60,7 @@ class TestFeaturizer(unittest.TestCase):
         self.assertIsInstance(predictor_reloaded, DegradationPredictor)
         # test nominal capacity is being generated
         self.assertEqual(predictor_reloaded.nominal_capacity, 1.0628421000000001)
+        os.remove(os.path.join(TEST_FILE_DIR, "2017-12-04_4_65C-69per_6C_CH29_features_predict_only.json"))
 
     def test_feature_serialization_for_training(self):
         processed_cycler_run_path = os.path.join(TEST_FILE_DIR, processed_cycler_file)

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -13,14 +13,13 @@ from beep.structure import RawCyclerRun, ProcessedCyclerRun
 from beep.featurize import DegradationPredictor, process_file_list_from_json
 from monty.serialization import dumpfn, loadfn
 
-processed_cycler_file = "2017-06-30_2C-10per_6C_CH10_structure.json"
-processed_cycler_file_insuf = "structure_insufficient.json"
-maccor_file_w_diagnostics = os.path.join(TEST_FILE_DIR, "xTESLADIAG_000020_CH71.071")
-
-BIG_FILE_TESTS = os.environ.get("BEEP_BIG_TESTS", False)
-SKIP_MSG = "Tests requiring large files with diagnostic cycles are disabled, set BIG_FILE_TESTS to run full tests"
 TEST_DIR = os.path.dirname(__file__)
 TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
+PROCESSED_CYCLER_FILE = "2017-06-30_2C-10per_6C_CH10_structure.json"
+PROCESSED_CYCLER_FILE_INSUF = "structure_insufficient.json"
+MACCOR_FILE_W_DIAGNOSTICS = os.path.join(TEST_FILE_DIR, "xTESLADIAG_000020_CH71.071")
+BIG_FILE_TESTS = os.environ.get("BEEP_BIG_TESTS", False)
+SKIP_MSG = "Tests requiring large files with diagnostic cycles are disabled, set BIG_FILE_TESTS to run full tests"
 
 
 class TestFeaturizer(unittest.TestCase):
@@ -34,7 +33,7 @@ class TestFeaturizer(unittest.TestCase):
             self.events_mode = "events_off"
 
     def test_feature_generation_full_model(self):
-        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, processed_cycler_file)
+        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, PROCESSED_CYCLER_FILE)
         predictor = DegradationPredictor.from_processed_cycler_run_file(processed_cycler_run_path,
                                                                         features_label='full_model')
         self.assertEqual(len(predictor.X), 1)  # just test if works for now
@@ -42,13 +41,13 @@ class TestFeaturizer(unittest.TestCase):
         self.assertFalse(np.any(predictor.X.isnull()))
 
     def test_feature_label_full_model(self):
-        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, processed_cycler_file)
+        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, PROCESSED_CYCLER_FILE)
         predictor = DegradationPredictor.from_processed_cycler_run_file(processed_cycler_run_path,
                                                                         features_label='full_model')
         self.assertEqual(predictor.feature_labels[4], "charge_time_cycles_1:5")  
 
     def test_feature_serialization(self):
-        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, processed_cycler_file)
+        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, PROCESSED_CYCLER_FILE)
         predictor = DegradationPredictor.from_processed_cycler_run_file(processed_cycler_run_path,
                                                                         prediction_type = 'multi',
                                                                         features_label='full_model')
@@ -87,10 +86,10 @@ class TestFeaturizer(unittest.TestCase):
                                                          diagnostic_features=True)
         diagnostic_feature_label = predictor.feature_labels[-1]
         self.assertEqual(diagnostic_feature_label, "median_diagnostic_cycles_discharge_capacity")
-        np.testing.assert_almost_equal(predictor.X[diagnostic_feature_label][0], 4.481564593,  decimal=8)
+        np.testing.assert_almost_equal(predictor.X[diagnostic_feature_label][0], 4.481564593, decimal=8)
 
     def test_feature_generation_list_to_json(self):
-        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, processed_cycler_file)
+        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, PROCESSED_CYCLER_FILE)
         # Create dummy json obj
         json_obj = {
                     "mode": self.events_mode,
@@ -111,7 +110,7 @@ class TestFeaturizer(unittest.TestCase):
         self.assertEqual(predictor_reloaded.nominal_capacity, 1.0628421000000001)
 
     def test_insufficient_data_file(self):
-        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, processed_cycler_file_insuf)
+        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, PROCESSED_CYCLER_FILE_INSUF)
 
         json_obj = {
                     "mode": self.events_mode,

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -9,7 +9,6 @@ import boto3
 import numpy as np
 from botocore.exceptions import NoRegionError, NoCredentialsError
 
-from beep import TEST_FILE_DIR
 from beep.structure import RawCyclerRun, ProcessedCyclerRun
 from beep.featurize import DegradationPredictor, process_file_list_from_json
 from monty.serialization import dumpfn, loadfn
@@ -20,6 +19,8 @@ maccor_file_w_diagnostics = os.path.join(TEST_FILE_DIR, "xTESLADIAG_000020_CH71.
 
 BIG_FILE_TESTS = os.environ.get("BEEP_BIG_TESTS", False)
 SKIP_MSG = "Tests requiring large files with diagnostic cycles are disabled, set BIG_FILE_TESTS to run full tests"
+TEST_DIR = os.path.dirname(__file__)
+TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
 
 
 class TestFeaturizer(unittest.TestCase):
@@ -59,7 +60,6 @@ class TestFeaturizer(unittest.TestCase):
         self.assertIsInstance(predictor_reloaded, DegradationPredictor)
         # test nominal capacity is being generated
         self.assertEqual(predictor_reloaded.nominal_capacity, 1.0628421000000001)
-        os.remove(os.path.join(TEST_FILE_DIR, "2017-12-04_4_65C-69per_6C_CH29_features_predict_only.json"))
 
     def test_feature_serialization_for_training(self):
         processed_cycler_run_path = os.path.join(TEST_FILE_DIR, processed_cycler_file)

--- a/beep/tests/test_features.py
+++ b/beep/tests/test_features.py
@@ -62,7 +62,7 @@ class TestFeaturizer(unittest.TestCase):
         os.remove(os.path.join(TEST_FILE_DIR, "2017-12-04_4_65C-69per_6C_CH29_features_predict_only.json"))
 
     def test_feature_serialization_for_training(self):
-        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, processed_cycler_file)
+        processed_cycler_run_path = os.path.join(TEST_FILE_DIR, PROCESSED_CYCLER_FILE)
         predictor = DegradationPredictor.from_processed_cycler_run_file(processed_cycler_run_path,
                                                                         features_label='full_model', predict_only=False)
         dumpfn(predictor, os.path.join(TEST_FILE_DIR, "2017-12-04_4_65C-69per_6C_CH29_features.json"))

--- a/beep/tests/test_models.py
+++ b/beep/tests/test_models.py
@@ -108,6 +108,8 @@ class TestRunModel(unittest.TestCase):
         self.assertEqual(features.nominal_capacity, 1.0628421000000001)
         self.assertFalse((prediction_reloaded['discharge_capacity'] -
                          np.around(np.arange(.98, 0.78, -0.03), 2) * features.nominal_capacity).any())
+        os.remove(os.path.join(TEST_FILE_DIR, '2017-06-30_2C-10per_6C_CH10_full_model_multi_predictions.json'))
+
 
     def test_single_task_prediction_list_to_json(self):
         featurized_jsons = glob(os.path.join(SINGLE_TASK_FEATURES_PATH, "*features.json"))

--- a/beep/tests/test_models.py
+++ b/beep/tests/test_models.py
@@ -6,15 +6,18 @@ import os
 import json
 import numpy as np
 from glob import glob
-from beep import TEST_FILE_DIR, MODEL_DIR
+from beep import MODEL_DIR
 from beep.run_model import DegradationModel, process_file_list_from_json, get_project_name_from_list
 from monty.serialization import loadfn
 
 import boto3
 from botocore.exceptions import NoRegionError, NoCredentialsError
-single_task_features_path = os.path.join(
+
+TEST_DIR = os.path.dirname(__file__)
+TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
+SINGLE_TASK_FEATURES_PATH = os.path.join(
     TEST_FILE_DIR, "feature_jsons_for_training_model", "single_task")
-multi_task_features_path = os.path.join(
+MULTI_TASK_FEATURES_PATH = os.path.join(
     TEST_FILE_DIR, "feature_jsons_for_training_model", "multi_task")
 
 
@@ -30,7 +33,7 @@ class TestRunModel(unittest.TestCase):
 
     def test_model_training_and_serialization(self):
         # tests for model training and serialization
-        featurized_jsons = glob(os.path.join(single_task_features_path, "*features.json"))
+        featurized_jsons = glob(os.path.join(SINGLE_TASK_FEATURES_PATH, "*features.json"))
         json_obj = {
             "mode": self.events_mode,
             "file_list": featurized_jsons,
@@ -45,10 +48,9 @@ class TestRunModel(unittest.TestCase):
         serialized_model_reloaded = DegradationModel.from_serialized_model(
             model_dir=TEST_FILE_DIR, serialized_model=model.name + '.model')
         self.assertIsInstance(serialized_model_reloaded, DegradationModel)
-        os.remove(os.path.join(TEST_FILE_DIR, 'test_model.model'))
 
     def test_multi_task_model_training(self):
-        featurized_jsons = glob(os.path.join(multi_task_features_path, "*features.json"))
+        featurized_jsons = glob(os.path.join(MULTI_TASK_FEATURES_PATH, "*features.json"))
         json_obj = {
             "mode": self.events_mode,
             "file_list": featurized_jsons,
@@ -66,7 +68,7 @@ class TestRunModel(unittest.TestCase):
         self.assertIsInstance(serialized_model_reloaded, DegradationModel)
 
     def test_multi_task_prediction_list_to_json(self):
-        featurized_jsons = glob(os.path.join(multi_task_features_path, "*features.json"))
+        featurized_jsons = glob(os.path.join(MULTI_TASK_FEATURES_PATH, "*features.json"))
         json_obj = {
             "mode": self.events_mode,
             "file_list": featurized_jsons,
@@ -74,7 +76,7 @@ class TestRunModel(unittest.TestCase):
         }
         json_string = json.dumps(json_obj)
         newjsonpaths = process_file_list_from_json(json_string, model_dir=MODEL_DIR,
-                                                   processed_dir=multi_task_features_path, predict_only=True)
+                                                   processed_dir=MULTI_TASK_FEATURES_PATH, predict_only=True)
         reloaded = json.loads(newjsonpaths)
 
         prediction_reloaded = loadfn(reloaded['file_list'][0])
@@ -84,7 +86,7 @@ class TestRunModel(unittest.TestCase):
         # Testing error output
         self.assertIsInstance(prediction_reloaded['fractional_error'], np.ndarray)
         self.assertEqual(len(prediction_reloaded['fractional_error']), 1)  # for now just a single fractional error
-        predictions = glob(os.path.join(multi_task_features_path, "*predictions.json"))
+        predictions = glob(os.path.join(MULTI_TASK_FEATURES_PATH, "*predictions.json"))
         for file in predictions:
             os.remove(file)
 
@@ -106,10 +108,9 @@ class TestRunModel(unittest.TestCase):
         self.assertEqual(features.nominal_capacity, 1.0628421000000001)
         self.assertFalse((prediction_reloaded['discharge_capacity'] -
                          np.around(np.arange(.98, 0.78, -0.03), 2) * features.nominal_capacity).any())
-        os.remove(os.path.join(TEST_FILE_DIR, '2017-06-30_2C-10per_6C_CH10_full_model_multi_predictions.json'))
 
     def test_single_task_prediction_list_to_json(self):
-        featurized_jsons = glob(os.path.join(single_task_features_path, "*features.json"))
+        featurized_jsons = glob(os.path.join(SINGLE_TASK_FEATURES_PATH, "*features.json"))
         json_obj = {
             "mode": self.events_mode,
             "file_list": featurized_jsons,
@@ -117,7 +118,7 @@ class TestRunModel(unittest.TestCase):
         }
         json_string = json.dumps(json_obj)
         newjsonpaths = process_file_list_from_json(json_string, model_dir=MODEL_DIR,
-                                                   processed_dir=single_task_features_path, predict_only=True)
+                                                   processed_dir=SINGLE_TASK_FEATURES_PATH, predict_only=True)
         reloaded = json.loads(newjsonpaths)
 
         # Ensure first is correct
@@ -126,7 +127,7 @@ class TestRunModel(unittest.TestCase):
         # Testing error output
         self.assertIsInstance(prediction_reloaded['fractional_error'], np.ndarray)
 
-        predictions = glob(os.path.join(single_task_features_path, "*predictions.json"))
+        predictions = glob(os.path.join(SINGLE_TASK_FEATURES_PATH, "*predictions.json"))
         for file in predictions:
             os.remove(file)
 

--- a/beep/tests/test_principal_components.py
+++ b/beep/tests/test_principal_components.py
@@ -3,9 +3,12 @@ import json
 import os
 import unittest
 import numpy as np
-from beep import TEST_FILE_DIR
 from sklearn.decomposition import PCA
 from beep.principal_components import PrincipalComponents, pivot_data
+
+TEST_DIR = os.path.dirname(__file__)
+TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
+
 
 class PrincipalComponentsTest(unittest.TestCase):
     def setUp(self):

--- a/beep/tests/test_protocol.py
+++ b/beep/tests/test_protocol.py
@@ -6,7 +6,7 @@ import unittest
 import json
 import boto3
 import datetime
-from beep import TEST_FILE_DIR, PROCEDURE_TEMPLATE_DIR
+from beep import PROCEDURE_TEMPLATE_DIR
 from beep.generate_protocol import ProcedureFile, \
     generate_protocol_files_from_csv
 from monty.tempfile import ScratchDir
@@ -14,6 +14,9 @@ from monty.serialization import dumpfn, loadfn
 from monty.os import makedirs_p
 from botocore.exceptions import NoRegionError, NoCredentialsError
 import difflib
+
+TEST_DIR = os.path.dirname(__file__)
+TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
 
 
 class GenerateProcedureTest(unittest.TestCase):

--- a/beep/tests/test_splice.py
+++ b/beep/tests/test_splice.py
@@ -4,8 +4,10 @@
 import os
 import unittest
 import numpy as np
-from beep import TEST_FILE_DIR
 from beep.utils import MaccorSplice
+
+TEST_DIR = os.path.dirname(__file__)
+TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
 
 
 class SpliceTest(unittest.TestCase):

--- a/beep/tests/test_structure.py
+++ b/beep/tests/test_structure.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 from botocore.exceptions import NoRegionError, NoCredentialsError
 
-from beep import TEST_FILE_DIR, MODULE_DIR
+from beep import MODULE_DIR
 from beep.structure import RawCyclerRun, ProcessedCyclerRun, \
     process_file_list_from_json, EISpectrum, get_project_sequence, \
     get_protocol_parameters, get_diagnostic_parameters
@@ -21,6 +21,8 @@ import matplotlib.pyplot as plt
 
 BIG_FILE_TESTS = os.environ.get("BEEP_BIG_TESTS", False)
 SKIP_MSG = "Tests requiring large files with diagnostic cycles are disabled, set BIG_FILE_TESTS to run full tests"
+TEST_DIR = os.path.dirname(__file__)
+TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
 
 
 class RawCyclerRunTest(unittest.TestCase):

--- a/beep/tests/test_validate.py
+++ b/beep/tests/test_validate.py
@@ -13,7 +13,10 @@ from botocore.exceptions import NoRegionError, NoCredentialsError
 from monty.tempfile import ScratchDir
 from beep.validate import ValidatorBeep, validate_file_list_from_json, \
     SimpleValidator
-from beep import TEST_FILE_DIR, S3_CACHE, VALIDATION_SCHEMA_DIR
+from beep import S3_CACHE, VALIDATION_SCHEMA_DIR
+
+TEST_DIR = os.path.dirname(__file__)
+TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
 
 
 @unittest.skip

--- a/beep/utils/events.py
+++ b/beep/utils/events.py
@@ -12,7 +12,7 @@ import watchtower
 import numpy as np
 import boto3
 import pytz
-from beep import TEST_FILE_DIR
+from beep import LOG_DIR
 
 
 class Logger:
@@ -71,7 +71,7 @@ class KinesisEvents:
             self.kinesis = boto3.client('kinesis', region_name='us-west-2')
 
         if self.mode == 'events_off':
-            self.logger = Logger(log_file=os.path.join(TEST_FILE_DIR, "Event_logger.log"))
+            self.logger = Logger(log_file=os.path.join(LOG_DIR, "Event_logger.log"))
 
     def get_file_size(self, file_list):
         """

--- a/beep/utils/splice.py
+++ b/beep/utils/splice.py
@@ -17,7 +17,7 @@ Options:
 """
 import pandas as pd
 from beep import StringIO
-from beep import TEST_FILE_DIR
+from beep import LOG_DIR
 import os
 
 
@@ -115,17 +115,3 @@ class MaccorSplice:
         data_1, data_2 = self.column_increment(data_1, data_2)
         data_final = self.splice_operation(data_1, data_2)
         self.write_maccor_file(metadata_line_1, data_final, self.output)
-
-
-if __name__ == "__main__":
-    filename_part_1 = '/Users/patrickherring/Downloads/xTESLADIAG_000038.078'
-    filename_part_2 = '/Users/patrickherring/Downloads/xTESLADIAG_000038con.078'
-    test = '/Users/patrickherring/Downloads/xTESLADIAG_000038test.078'
-    output = '/Users/patrickherring/Downloads/xTESLADIAG_000038joined.078'
-
-    filename_part_1 = os.path.join(TEST_FILE_DIR, "xTESLADIAG_000038.078")
-    filename_part_2 = os.path.join(TEST_FILE_DIR, "xTESLADIAG_000038con.078")
-    output = os.path.join(TEST_FILE_DIR, "xTESLADIAG_000038joined.078")
-
-    splicer = MaccorSplice(filename_part_1, filename_part_2, output)
-    splicer.run_splice()


### PR DESCRIPTION
This PR is isolating all of the python logic for the tests into the tests, which consists of:

* Declaring TEST_DIR and TEST_FILES_DIR in each test
* Removing TEST_DIR and TEST_FILES_DIR in beep.__init__.py
* Creates a dedicated LOG_DIR to replace the use of TEST_FILE_DIR in beep.events and beep.splice

Also:
* Few housekeeping things (upper-case module-level constants)