### PR TITLE
add waveform step

### DIFF
--- a/beep/generate_protocol.py
+++ b/beep/generate_protocol.py
@@ -337,6 +337,27 @@ class ProcedureFile:
 
         return proc_dict
 
+    def insert_maccor_waveform_discharge(self, proc_dict, waveform_idx, waveform_filename):
+        """
+        Inserts a waveform into procedure dictionary at given id.
+
+        Args:
+            proc_dict (dict): dictionary of procedure parameters associated
+                with a procedure template file
+            waveform_idx (int): Step in the procedure file to insert waveform at
+            waveform_filename (str): Path to .MWF waveform file. Waveform needs to be pre-scaled for
+            current/power capabilities of the cell and cycler
+
+        Returns:
+            dict:
+        """
+        steps = proc_dict['MaccorTestProcedure']['ProcSteps']['TestStep']
+        assert steps[waveform_idx]['StepType'] == "FastWave"
+
+        steps[waveform_idx]['StepValue'] = waveform_filename.split('.MWF')[0]
+
+        return proc_dict
+
     def insert_resistance_regcyclev2(self, proc_dict, resist_idx, reg_param):
         """
         Inserts resistance into procedure dictionary at given id.


### PR DESCRIPTION
Method to add waveform step (based on drive-cycle) into the procedure file.
This can be invoked from one of the procedure generation functions once we have an appropriate template to get the right step number from.