### PR TITLE
Switch over the kinesis event stream name 

### DIFF
--- a/beep/config.py
+++ b/beep/config.py
@@ -10,6 +10,9 @@ config = {
         'logging': {
             'container': 'Testing',
             'streams': ['CloudWatch']
+        },
+        'kinesis': {
+            'stream': 'local/beep/eventstream'
         }
     },
 
@@ -17,6 +20,9 @@ config = {
         'logging': {
             'container': 'Testing',
             'streams': ['file']
+        },
+        'kinesis': {
+            'stream': 'local/beep/eventstream'
         }
     },
 
@@ -24,6 +30,9 @@ config = {
         'logging': {
             'container': 'Testing',
             'streams': ['CloudWatch']
+        },
+        'kinesis': {
+            'stream': 'local/beep/eventstream'
         }
     },
 
@@ -31,6 +40,9 @@ config = {
         'logging': {
             'container': 'BEEP_EP',
             'streams': ['CloudWatch']
+        },
+        'kinesis': {
+            'stream': 'stage/beep/eventstream/stage'
         }
     },
 

--- a/beep/tests/test_events.py
+++ b/beep/tests/test_events.py
@@ -10,6 +10,8 @@ import boto3
 from dateutil.tz import tzutc
 from botocore.exceptions import NoRegionError, NoCredentialsError
 from beep.utils import KinesisEvents, Logger
+from beep.utils.secrets_manager import get_secret
+from beep.config import config
 from beep import ENVIRONMENT, __version__
 
 TEST_DIR = os.path.dirname(__file__)
@@ -28,7 +30,8 @@ class KinesisEventsTest(unittest.TestCase):
         beep_kinesis_connection_broken = True
 
     def setUp(self):
-        pass
+        self.assertEqual('kinesis-test',
+                         get_secret(config[ENVIRONMENT]['kinesis']['stream'])['streamName'])
 
     def test_get_file_size(self):
         events = KinesisEvents(service='Testing', mode='test')

--- a/beep/utils/events.py
+++ b/beep/utils/events.py
@@ -12,7 +12,9 @@ import watchtower
 import numpy as np
 import boto3
 import pytz
-from beep import LOG_DIR
+from beep import LOG_DIR, ENVIRONMENT
+from beep.config import config
+from beep.utils.secrets_manager import get_secret
 
 
 class Logger:
@@ -63,11 +65,11 @@ class KinesisEvents:
         self.mode = mode
 
         if self.mode == 'run':
-            self.stream = 'beep-events'
+            self.stream = get_secret(config[ENVIRONMENT]['kinesis']['stream'])['streamName']
             self.kinesis = boto3.client('kinesis', region_name='us-west-2')
 
         if self.mode == 'test':
-            self.stream = 'kinesis-test'
+            self.stream = get_secret(config[ENVIRONMENT]['kinesis']['stream'])['streamName']
             self.kinesis = boto3.client('kinesis', region_name='us-west-2')
 
         if self.mode == 'events_off':

--- a/beep/utils/secrets_manager.py
+++ b/beep/utils/secrets_manager.py
@@ -1,0 +1,70 @@
+"""
+Module to provide connection objects to various postgres environments.
+
+Current environments:
+- local     Local development environment. Non-secret credentials.
+- stage     Beep stage environment. Credentials to database instance are
+            obtained through AWS SecretsManager.
+
+"""
+
+import boto3
+import base64
+from botocore.exceptions import ClientError
+import json
+
+from beep.config import config
+
+
+def secret_accessible(environment):
+    pg_config = config[environment]['postgres']
+    if 'secret' in pg_config:
+        secret_name = pg_config['secret']
+        try:
+            _ = get_secret(secret_name)
+        except Exception as e:
+            return False
+        else:
+            return True
+    else:
+        return True
+
+
+def get_secret(secret_name):
+    """
+    Returns the secret for the beep database and respective environment.
+
+    Args:
+        secret_name:    str representing the location in secrets manager
+
+    Returns:
+        secret          dict object containing database credentials
+
+    """
+    region_name = 'us-west-2'
+
+    # Create a Secrets Manager client
+    session = boto3.session.Session()
+    client = session.client(
+        service_name='secretsmanager',
+        region_name=region_name
+    )
+
+    try:
+        get_secret_value_response = client.get_secret_value(
+            SecretId=secret_name
+        )
+    except ClientError as e:
+        raise e
+    else:
+        # Decrypts secret using the associated KMS CMK.
+        # Depending on whether the secret is a string or binary,
+        # one of these fields will be populated.
+        if 'SecretString' in get_secret_value_response:
+            secret = get_secret_value_response['SecretString']
+            return json.loads(secret)
+        else:
+            decoded_binary_secret = base64.b64decode(
+                get_secret_value_response['SecretBinary'])
+            return json.loads(decoded_binary_secret)
+


### PR DESCRIPTION
This PR changes the configuration of the kinesis stream so that it pulls from secrets manager instead of being hardcoded.

WARNING: This is a breaking change for ECS so should not be merged into master until we have switched to Kubernetes